### PR TITLE
Fix syslog identifier

### DIFF
--- a/templates/systemd/php-fpm_exporter.service.j2
+++ b/templates/systemd/php-fpm_exporter.service.j2
@@ -11,7 +11,7 @@ User = {{ php_fpm_exporter_system_user }}
 Group = {{ php_fpm_exporter_system_group }}
 ExecReload = /bin/kill -HUP $MAINPID
 ExecStart = {{ php_fpm_exporter_install_dir }}/{{ php_fpm_exporter_binary }} server $ADDITIONAL_ARGS
-SyslogIdentifier = nginx_exporter
+SyslogIdentifier = php_fpm_exporter
 Restart = always
 
 [Install]


### PR DESCRIPTION
Show the correct syslog identifier in syslog to not confuse people

## Résumé par Sourcery

Corrections de bugs :
- Correction de l'identifiant syslog pour éviter toute confusion.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct the syslog identifier to avoid confusion.

</details>